### PR TITLE
feat: add JSON and estimate size support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: denoland/setup-deno@v2
 
       - name: Run tests
-        run: deno test -A
+        run: deno task test
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,85 @@
 # @deno/kv-utils
 
-> The utilities for working with Deno KV
+Utilities for working with Deno KV.
+
+## Working with JSON
+
+`Deno.Kv` stores are able to store values that are serializable using the
+structured clone algorithm. The challenge is that supports a lot of types that
+are not serializable using JSON. To work around this, you can use the the
+utilities to convert values which can be safely serialized to JSON as well as
+deserialize them back. This makes it possible to fully represent entries and
+values in a browser, or communicate them between Deno processes.
+
+The JSON utilities are:
+
+- `entryMaybeToJSON` - Convert a `Deno.KvEntryMaybe` to JSON.
+- `entryToJSON` - Convert a `Deno.KvEntry` to JSON.
+- `keyToJSON` - Convert a `Deno.KvKey` to JSON.
+- `keyPartToJSON` - Convert a `Deno.KvKeyPart` to JSON.
+- `valueToJSON` - Convert a value which can be stored in Deno KV to JSON.
+- `toEntry` - Convert a JSON object to a `Deno.KvEntry`.
+- `toEntryMaybe` - Convert a JSON object to a `Deno.KvEntryMaybe`.
+- `toKey` - Convert a JSON object to a `Deno.KvKey`.
+- `toKeyPart` - Convert a JSON object to a `Deno.KvKeyPart`.
+- `toValue` - Convert a JSON object to a value which can be stored in Deno KV.
+
+### Examples
+
+Taking a maybe entry from Deno.Kv and converting it to JSON and sending it as a
+response:
+
+```ts ignore
+import { entryMaybeToJSON } from "@deno/kv-utils";
+
+const db = await Deno.openKv();
+
+Deno.serve(async (_req) => {
+  const maybeEntry = await db.get(["a"]);
+  const json = entryMaybeToJSON(maybeEntry);
+  return Response.json(json);
+});
+```
+
+Taking a value that was serialized to JSON in a browser and storing it in Deno
+KV:
+
+```ts ignore
+import { toValue } from "@deno/kv-utils";
+
+const db = await Deno.openKv();
+
+Deno.serve(async (req) => {
+  const json = await req.json();
+  const value = toValue(json);
+  await db.set(["a"], value);
+  return new Response(null, { status: 204 });
+});
+```
+
+## Estimating the size of a value
+
+When working with Deno KV and there is a need to have transactions be
+infallible, it is helpful to be able to estimate the size of a value before
+storing it. This is because there are limits on the size of values that can be
+stored in Deno KV, as well as the size of atomic operations.
+
+Deno KV stores values by using the V8 serialization format, which converts
+objects to a binary format and then that value is stored in the KV store.
+
+The `estimateSize} function can be used to estimate the size of a value in
+bytes. While it is not 100% accurate, it is 10x faster than using the V8
+serialize function, which is not available in some environments.
+
+### Example
+
+```ts
+import { estimateSize } from "@deno/kv-utils";
+import { assertEquals } from "@std/assert";
+
+const value = { a: new Map([[{ a: 1 }, { b: /234/ }]]), b: false };
+assertEquals(estimateSize(value), 36);
+```
 
 # License
 

--- a/_benches/byte_size.ts
+++ b/_benches/byte_size.ts
@@ -1,0 +1,42 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * A benchmark comparing the byte size of a value using different methods.
+ *
+ * @module
+ */
+
+import { Serializer } from "jsr:@denostack/superserial@0.3.5";
+import { serialize } from "node:v8";
+import { estimateSize } from "../estimate_size.ts";
+
+const fixture = {
+  "🦕": /abcd/i,
+  nested: { a: new Set([{}, 2, 3]) },
+  buffer: [new Uint8Array(65_000), new Uint8Array(65_000)],
+  longString: "a".repeat(2_000),
+};
+
+Deno.bench({
+  name: "serialize().byteLength",
+  fn() {
+    serialize(fixture).byteLength;
+  },
+});
+
+Deno.bench({
+  name: "estimateSize()",
+  fn() {
+    estimateSize(fixture);
+  },
+});
+
+const serializer = new Serializer();
+const encoder = new TextEncoder();
+
+Deno.bench({
+  name: "superserial serializer.serialize()",
+  fn() {
+    encoder.encode(serializer.serialize(fixture)).byteLength;
+  },
+});

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,31 @@
   "name": "@deno/kv-utils",
   "version": "0.0.0",
   "exports": {
-    ".": "./mod.ts"
+    ".": "./mod.ts",
+    "./json": "./json.ts",
+    "./estimate-size": "./estimate_size.ts"
+  },
+  "publish": {
+    "exclude": [".github", "_benches", "*_test.ts"]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.6",
+    "@std/crypto": "jsr:@std/crypto@^1.0.3",
+    "@std/encoding": "jsr:@std/encoding@^1.0.5"
+  },
+  "tasks": {
+    "bench": "deno bench _benches/*.ts",
+    "test": "deno test --allow-net --unstable-kv --doc"
+  },
+  "lint": {
+    "rules": {
+      "include": [
+        "camelcase",
+        "no-sync-fn-in-async-fn",
+        "single-var-declarator",
+        "verbatim-module-syntax",
+        "no-console"
+      ]
+    }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,49 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@denostack/superserial@0.3.5": "0.3.5",
+    "jsr:@std/assert@^1.0.6": "1.0.6",
+    "jsr:@std/crypto@^1.0.3": "1.0.3",
+    "jsr:@std/encoding@^1.0.5": "1.0.5",
+    "jsr:@std/internal@^1.0.4": "1.0.4",
+    "npm:@types/node@*": "22.5.4"
+  },
+  "jsr": {
+    "@denostack/superserial@0.3.5": {
+      "integrity": "081019681862c8ae32dc8d754824ef967aa1f69138c7792517bf12163250aa08"
+    },
+    "@std/assert@1.0.6": {
+      "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/crypto@1.0.3": {
+      "integrity": "a2a32f51ddef632d299e3879cd027c630dcd4d1d9a5285d6e6788072f4e51e7f"
+    },
+    "@std/encoding@1.0.5": {
+      "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
+    },
+    "@std/internal@1.0.4": {
+      "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
+    }
+  },
+  "npm": {
+    "@types/node@22.5.4": {
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "undici-types@6.19.8": {
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.6",
+      "jsr:@std/crypto@^1.0.3",
+      "jsr:@std/encoding@^1.0.5"
+    ]
+  }
+}

--- a/estimate_size.test.ts
+++ b/estimate_size.test.ts
@@ -1,0 +1,160 @@
+// Copyright 2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+
+import { estimateSize } from "./estimate_size.ts";
+
+Deno.test({
+  name: "estimateSize - string",
+  fn() {
+    assertEquals(estimateSize("abcdefghijklmnopq"), 21);
+    assertEquals(estimateSize("🥟🥟"), 12);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - number",
+  fn() {
+    assertEquals(estimateSize(63), 4);
+    assertEquals(estimateSize(64), 5);
+    assertEquals(estimateSize(8_191), 5);
+    assertEquals(estimateSize(8_192), 6);
+    assertEquals(estimateSize(1_048_575), 6);
+    assertEquals(estimateSize(1_048_576), 7);
+    assertEquals(estimateSize(134_217_727), 7);
+    assertEquals(estimateSize(134_217_728), 8);
+    assertEquals(estimateSize(2_147_483_647), 8);
+    assertEquals(estimateSize(2_147_483_648), 11);
+    assertEquals(estimateSize(Number.MAX_SAFE_INTEGER), 11);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - boolean",
+  fn() {
+    assertEquals(estimateSize(true), 3);
+    assertEquals(estimateSize(false), 3);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - bigint",
+  fn() {
+    assertEquals(estimateSize(63n), 12);
+    assertEquals(estimateSize(BigInt(Number.MAX_SAFE_INTEGER + 1)), 12);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - undefined",
+  fn() {
+    assertEquals(estimateSize(undefined), 3);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - null",
+  fn() {
+    assertEquals(estimateSize(null), 3);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Date",
+  fn() {
+    assertEquals(estimateSize(new Date()), 11);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - RegExp",
+  fn() {
+    assertEquals(estimateSize(/ab[cdefg]hijklmnopq/ig), 25);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Error",
+  fn() {
+    assertAlmostEquals(
+      estimateSize(new URIError("boo hoo", { cause: new Error("boo") })),
+      496,
+      100,
+    );
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Uint8Array",
+  fn() {
+    assertEquals(estimateSize(new Uint8Array([1, 2, 3])), 12);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - ArrayBuffer",
+  fn() {
+    assertEquals(estimateSize(new Uint8Array([1, 2, 3]).buffer), 12);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Array",
+  fn() {
+    assertEquals(estimateSize([1, 2, 3, "boo", true, false, /abc/]), 27);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Set",
+  fn() {
+    assertEquals(estimateSize(new Set([1, 2, 3, 4, "foo"])), 18);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Map",
+  fn() {
+    assertEquals(
+      estimateSize(
+        new Map<string, string | number>([["a", 1], ["b", 2], ["c", "d"]]),
+      ),
+      21,
+    );
+  },
+});
+
+Deno.test({
+  name: "estimateSize - object",
+  fn() {
+    assertEquals(
+      estimateSize({ a: new Map([[{ a: 1 }, { b: /234/ }]]), b: false }),
+      36,
+    );
+  },
+});
+
+Deno.test({
+  name: "estimateSize - Deno.KvU64",
+  fn() {
+    assertEquals(estimateSize(new Deno.KvU64(100n)), 12);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - object with circular reference",
+  fn() {
+    // deno-lint-ignore no-explicit-any
+    const a = { b: 1 as any };
+    const b = { a };
+    a.b = b;
+    assertEquals(estimateSize(a), 11);
+  },
+});
+
+Deno.test({
+  name: "estimateSize - symbol",
+  fn() {
+    assertEquals(estimateSize(Symbol.for("@deno/kv-utils")), 0);
+  },
+});

--- a/estimate_size.ts
+++ b/estimate_size.ts
@@ -1,0 +1,212 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * A module to estimate the byte size of a value.
+ *
+ * @module
+ */
+
+const encoder = new TextEncoder();
+const hasKvU64 = "Deno" in globalThis && typeof Deno.KvU64 === "function";
+
+/**
+ * Estimates the size of a string in bytes.
+ *
+ * @param str The string to calculate the size of
+ * @returns The size of the string in bytes
+ * @private
+ */
+function sizeOfString(str: string) {
+  return encoder.encode(str).byteLength + 4;
+}
+
+/**
+ * Estimates the size of an error in bytes.
+ *
+ * @param seen A set of objects that have already been seen
+ * @param error The error to calculate the size of
+ * @returns The size of the error in bytes
+ * @private
+ */
+function sizeOfError(seen: WeakSet<object>, error: Error) {
+  seen.add(error);
+  let bytes = error.name.length + sizeOfString(error.message);
+  if (error.stack) {
+    bytes += sizeOfString(error.stack);
+  }
+  if (error.cause) {
+    bytes += getCalc(seen)(error.cause);
+  }
+  return bytes - 4;
+}
+
+/**
+ * Estimate the size of a map in bytes.
+ *
+ * @param seen A set of objects that have already been seen
+ * @param map The map to calculate the size of
+ * @returns The size of the map in bytes
+ * @private
+ */
+function sizeOfMap(seen: WeakSet<object>, map: Map<unknown, unknown>) {
+  seen.add(map);
+  let bytes = 0;
+  for (const [key, value] of map) {
+    bytes += getCalc(seen)(key) - 1;
+    bytes += getCalc(seen)(value) - 1;
+  }
+  return bytes - 1;
+}
+
+/**
+ * Estimate the size of a set in bytes.
+ *
+ * @param seen A set of objects that have already been seen
+ * @param set The set to calculate the size of
+ * @returns The size of the set in bytes
+ * @private
+ */
+function sizeOfSet(seen: WeakSet<object>, set: Set<unknown>) {
+  seen.add(set);
+  let bytes = 0;
+  for (const value of set) {
+    bytes += getCalc(seen)(value) - 1;
+  }
+  return bytes;
+}
+
+/**
+ * Estimate the size of an object in bytes.
+ *
+ * @param seen A set of objects that have already been seen
+ * @param value The object to calculate the size of
+ * @returns The size of the object in bytes
+ * @private
+ */
+function sizeOfObject(
+  seen: WeakSet<object>,
+  value: Record<string, unknown>,
+) {
+  let bytes = 0;
+  for (const key of Object.keys(value)) {
+    if (typeof value[key] === "object" && value[key] !== null) {
+      if (seen.has(value)) {
+        continue;
+      }
+      seen.add(value[key] as object);
+    }
+    bytes += getCalc(seen)(key);
+    try {
+      bytes += getCalc(seen)(value[key]);
+    } catch (error) {
+      if (error instanceof RangeError) {
+        bytes = 0;
+      }
+    }
+  }
+  return Math.max(bytes + 1, 5);
+}
+
+/**
+ * Create a function that calculates the size of a value.
+ *
+ * @param seen A set of objects that have already been seen
+ * @returns A function that calculates the size of a value
+ * @private
+ */
+function getCalc(seen: WeakSet<object>): (value: unknown) => number {
+  return function calc(value: unknown) {
+    switch (typeof value) {
+      case "string":
+        return sizeOfString(value);
+      case "boolean":
+        return 3;
+      case "number":
+        return value < 64
+          ? 4
+          : value < 8_192
+          ? 5
+          : value < 1_048_576
+          ? 6
+          : value < 134_217_728
+          ? 7
+          : value < 2_147_483_648
+          ? 8
+          : 11;
+      case "bigint":
+        return 12;
+      case "undefined":
+        return 3;
+      case "object":
+        if (value === null) {
+          return 3;
+        }
+        if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+          return value.byteLength + 9;
+        }
+        if (Array.isArray(value)) {
+          return value.map(getCalc(seen)).reduce(
+            (acc, curr) => acc + curr - 1,
+            0,
+          );
+        }
+        if (value instanceof Date) {
+          return 11;
+        }
+        if (value instanceof RegExp) {
+          return encoder.encode(value.source).byteLength + 6;
+        }
+        if (value instanceof Error) {
+          return sizeOfError(seen, value);
+        }
+        if (value instanceof Set) {
+          return sizeOfSet(seen, value);
+        }
+        if (value instanceof Map) {
+          return sizeOfMap(seen, value);
+        }
+        if (hasKvU64 && value instanceof Deno.KvU64) {
+          return 12;
+        }
+        return sizeOfObject(seen, value as Record<string | symbol, unknown>);
+      default:
+        return 0;
+    }
+  };
+}
+
+/**
+ * Estimates the size, in bytes, of the V8 serialized form of the value, which
+ * is used to determine the size of entries being stored in a Deno KV store.
+ *
+ * This is useful when you want to determine the size of a value before using
+ * it as a KV store entry. KV has a key part limit of 2k and a value limit of
+ * 64 KB. There are also limits on the total size of atomic operations.
+ *
+ * kv-toolbox uses this function to estimate the size of items being stored as
+ * blobs in the KV store, as well as the size of atomic operations.
+ *
+ * A more accurate estimate can be obtained by using the V8 `serialize` function
+ * but this isn't available in some environments, as well as being 10x slower
+ * than this function.
+ *
+ * > [!NOTE]
+ * > The size of the value is an estimate and may not be 100% accurate. Also,
+ * > a size of the operation may have some opaque overhead. Users should err on
+ * > the side of caution and keep the size of the value below the limits.
+ *
+ * @param value The value to estimate the size of
+ * @returns The estimated size of the value in bytes
+ * @example Get the size of a value
+ *
+ * ```ts
+ * import { estimateSize } from "@deno/kv-utils/estimate-size";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = { a: new Map([[{ a: 1 }, { b: /234/ }]]), b: false };
+ * assertEquals(estimateSize(value), 36);
+ * ```
+ */
+export function estimateSize(value: unknown): number {
+  return getCalc(new WeakSet())(value);
+}

--- a/json.test.ts
+++ b/json.test.ts
@@ -1,0 +1,1101 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "@std/assert";
+import { timingSafeEqual } from "@std/crypto/timing-safe-equal";
+
+import {
+  entryMaybeToJSON,
+  entryToJSON,
+  keyPartToJSON,
+  keyToJSON,
+  toEntry,
+  toEntryMaybe,
+  toKey,
+  toKeyPart,
+  toValue,
+  valueToJSON,
+} from "./json.ts";
+
+Deno.test({
+  name: "toValue - ArrayBuffer",
+  fn() {
+    assert(
+      timingSafeEqual(
+        toValue({ type: "ArrayBuffer", value: "AQID" }),
+        new Uint8Array([1, 2, 3]).buffer,
+      ),
+    );
+  },
+});
+
+Deno.test({
+  name: "toValue - Array",
+  fn() {
+    assertEquals(
+      toValue({
+        type: "Array",
+        value: [
+          { type: "number", value: 1 },
+          { type: "number", value: 2 },
+          { type: "number", value: 3 },
+        ],
+      }),
+      [1, 2, 3],
+    );
+  },
+});
+
+Deno.test({
+  name: "toValue - bigint",
+  fn() {
+    assertEquals(toValue({ type: "bigint", value: "100" }), 100n);
+  },
+});
+
+Deno.test({
+  name: "toValue - boolean",
+  fn() {
+    assertEquals(toValue({ type: "boolean", value: true }), true);
+  },
+});
+
+Deno.test({
+  name: "toValue - DataView",
+  fn() {
+    assert(
+      timingSafeEqual(
+        toValue({ type: "DataView", value: "AQID" }),
+        new DataView(new Uint8Array([1, 2, 3]).buffer),
+      ),
+    );
+  },
+});
+
+Deno.test({
+  name: "toValue - Date",
+  fn() {
+    const actual = toValue({ type: "Date", value: "2023-12-16T17:24:00.000Z" });
+    assert(actual instanceof Date);
+    assertEquals(actual.toISOString(), "2023-12-16T17:24:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "toValue - Error",
+  fn() {
+    const value = toValue({
+      type: "Error",
+      value: {
+        message: "an error",
+        stack: `Line\nLine`,
+        cause: {
+          type: "SyntaxError",
+          value: { message: "something else", stack: "Line\nLine" },
+        },
+      },
+    });
+    assert(value instanceof Error);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+    assert(value.cause instanceof SyntaxError);
+  },
+});
+
+Deno.test({
+  name: "toValue - EvalError",
+  fn() {
+    const value = toValue({
+      type: "EvalError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof EvalError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - RangeError",
+  fn() {
+    const value = toValue({
+      type: "RangeError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof RangeError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - ReferenceError",
+  fn() {
+    const value = toValue({
+      type: "ReferenceError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof ReferenceError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - SyntaxError",
+  fn() {
+    const value = toValue({
+      type: "SyntaxError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof SyntaxError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - TypeError",
+  fn() {
+    const value = toValue({
+      type: "TypeError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof TypeError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - URIError",
+  fn() {
+    const value = toValue({
+      type: "URIError",
+      value: { message: "an error", stack: `Line\nLine` },
+    });
+    assert(value instanceof URIError);
+    assertEquals(value.message, "an error");
+    assertEquals(value.stack, `Line\nLine`);
+  },
+});
+
+Deno.test({
+  name: "toValue - Deno.KvU64",
+  fn() {
+    const actual = toValue({ type: "KvU64", value: "100" });
+    assert(actual instanceof Deno.KvU64);
+    assertEquals(actual.value, new Deno.KvU64(100n).value);
+  },
+});
+
+Deno.test({
+  name: "toValue - Map",
+  fn() {
+    const actual = toValue({
+      type: "Map",
+      value: [[
+        { type: "string", value: "key" },
+        { type: "string", value: "value" },
+      ], [
+        { type: "string", value: "key2" },
+        { type: "string", value: "value2" },
+      ]],
+    });
+    assert(actual instanceof Map);
+    assertEquals(actual.size, 2);
+    assertEquals(actual.get("key"), "value");
+  },
+});
+
+Deno.test({
+  name: "toValue - null",
+  fn() {
+    assertStrictEquals(toValue({ type: "null", value: null }), null);
+  },
+});
+
+Deno.test({
+  name: "toValue - number",
+  fn() {
+    assertStrictEquals(toValue({ type: "number", value: 1.23 }), 1.23);
+  },
+});
+
+Deno.test({
+  name: "toValue - object",
+  fn() {
+    assertEquals(
+      toValue({
+        type: "object",
+        value: { foo: { type: "string", value: "bar" } },
+      }),
+      {
+        foo: "bar",
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toValue - RegExp",
+  fn() {
+    assertEquals(
+      toValue({ type: "RegExp", value: "/abc/i" }).toString(),
+      "/abc/i",
+    );
+  },
+});
+
+Deno.test({
+  name: "toValue - Set",
+  fn() {
+    const actual = toValue({
+      type: "Set",
+      value: [
+        { type: "number", value: 1 },
+        { type: "number", value: 2 },
+        { type: "number", value: 3 },
+      ],
+    });
+    assert(actual instanceof Set);
+    assertEquals(actual.size, 3);
+    assert(actual.has(1));
+  },
+});
+
+Deno.test({
+  name: "toValue - string",
+  fn() {
+    assertEquals(toValue({ type: "string", value: "foo" }), "foo");
+  },
+});
+
+Deno.test({
+  name: "toValue - Int8Array",
+  fn() {
+    const actual = toValue({ type: "Int8Array", value: "AQID" });
+    assert(actual instanceof Int8Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Uint8Array",
+  fn() {
+    const actual = toValue({ type: "Uint8Array", value: "AQID" });
+    assert(actual instanceof Uint8Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Uint8ClampedArray",
+  fn() {
+    const actual = toValue({ type: "Uint8ClampedArray", value: "AQID" });
+    assert(actual instanceof Uint8ClampedArray);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Int16Array",
+  fn() {
+    const actual = toValue({ type: "Int16Array", value: "AQIDBA" });
+    assert(actual instanceof Int16Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3, 4])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Uint16Array",
+  fn() {
+    const actual = toValue({ type: "Uint16Array", value: "AQIDBA" });
+    assert(actual instanceof Uint16Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3, 4])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Int32Array",
+  fn() {
+    const actual = toValue({ type: "Int32Array", value: "AQIDBA" });
+    assert(actual instanceof Int32Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3, 4])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Uint32Array",
+  fn() {
+    const actual = toValue({ type: "Uint32Array", value: "AQIDBA" });
+    assert(actual instanceof Uint32Array);
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3, 4])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Float32Array",
+  fn() {
+    const actual = toValue({ type: "Float32Array", value: "mpmZP5qZWUAzM7NA" });
+    assert(actual instanceof Float32Array);
+    assert(timingSafeEqual(actual, new Float32Array([1.2, 3.4, 5.6])));
+  },
+});
+
+Deno.test({
+  name: "toValue - Float64Array",
+  fn() {
+    const actual = toValue({
+      type: "Float64Array",
+      value: "MzMzMzMz8z8zMzMzMzMLQGZmZmZmZhZA",
+    });
+    assert(actual instanceof Float64Array);
+    assert(timingSafeEqual(actual, new Float64Array([1.2, 3.4, 5.6])));
+  },
+});
+
+Deno.test({
+  name: "toValue - BigInt64Array",
+  fn() {
+    const actual = toValue({
+      type: "BigInt64Array",
+      value: "AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA",
+    });
+    assert(actual instanceof BigInt64Array);
+    assert(timingSafeEqual(actual, new BigInt64Array([1n, 2n, 3n])));
+  },
+});
+
+Deno.test({
+  name: "toValue - BigUint64Array",
+  fn() {
+    const actual = toValue({
+      type: "BigUint64Array",
+      value: "AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA",
+    });
+    assert(actual instanceof BigUint64Array);
+    assert(timingSafeEqual(actual, new BigUint64Array([1n, 2n, 3n])));
+  },
+});
+
+Deno.test({
+  name: "toValue - undefined",
+  fn() {
+    assertStrictEquals(toValue({ type: "undefined" }), undefined);
+  },
+});
+
+Deno.test({
+  name: "toValue - throws TypeError on unknown type",
+  fn() {
+    assertThrows(
+      // deno-lint-ignore no-explicit-any
+      () => toValue({ type: "unknown" } as any),
+      TypeError,
+      'Unexpected value type: "unknown"',
+    );
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - ArrayBuffer",
+  fn() {
+    const ab = new Uint8Array([1, 2, 3]).buffer;
+    const actual = valueToJSON(ab);
+    assertEquals(actual, {
+      type: "ArrayBuffer",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Array",
+  fn() {
+    const actual = valueToJSON([1, 2, 3]);
+    assertEquals(actual, {
+      type: "Array",
+      value: [
+        { type: "number", value: 1 },
+        { type: "number", value: 2 },
+        { type: "number", value: 3 },
+      ],
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - bigint",
+  fn() {
+    const actual = valueToJSON(100n);
+    assertEquals(actual, {
+      type: "bigint",
+      value: "100",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - boolean",
+  fn() {
+    const actual = valueToJSON(false);
+    assertEquals(actual, {
+      type: "boolean",
+      value: false,
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - DataView",
+  fn() {
+    const dataView = new DataView(new Uint8Array([1, 2, 3]).buffer);
+    const actual = valueToJSON(dataView);
+    assertEquals(actual, {
+      type: "DataView",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Date",
+  fn() {
+    const actual = valueToJSON(new Date("2023-12-16T17:24:00.000Z"));
+    assertEquals(actual, {
+      type: "Date",
+      value: "2023-12-16T17:24:00.000Z",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Error",
+  fn() {
+    const actual = valueToJSON(
+      new Error("something", { cause: new SyntaxError("else") }),
+    );
+    assertEquals(actual.type, "Error");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+    assertEquals(actual.value.cause?.type, "SyntaxError");
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - custom Error",
+  fn() {
+    class CustomError extends Error {}
+    const actual = valueToJSON(
+      new CustomError("something"),
+    );
+    assertEquals(actual.type, "Error");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - EvalError",
+  fn() {
+    const actual = valueToJSON(new EvalError("something"));
+    assertEquals(actual.type, "EvalError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - RangeError",
+  fn() {
+    const actual = valueToJSON(new RangeError("something"));
+    assertEquals(actual.type, "RangeError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - ReferenceError",
+  fn() {
+    const actual = valueToJSON(new ReferenceError("something"));
+    assertEquals(actual.type, "ReferenceError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - SyntaxError",
+  fn() {
+    const actual = valueToJSON(new SyntaxError("something"));
+    assertEquals(actual.type, "SyntaxError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - TypeError",
+  fn() {
+    const actual = valueToJSON(new TypeError("something"));
+    assertEquals(actual.type, "TypeError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - URIError",
+  fn() {
+    const actual = valueToJSON(new URIError("something"));
+    assertEquals(actual.type, "URIError");
+    assertEquals(actual.value.message, "something");
+    assert(actual.value.stack);
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - KvU64",
+  fn() {
+    const actual = valueToJSON(new Deno.KvU64(100n));
+    assertEquals(actual, {
+      type: "KvU64",
+      value: "100",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Map",
+  fn() {
+    const actual = valueToJSON(new Map([["key", "value"]]));
+    assertEquals(actual, {
+      type: "Map",
+      value: [
+        [{ type: "string", value: "key" }, { type: "string", value: "value" }],
+      ],
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - null",
+  fn() {
+    const actual = valueToJSON(null);
+    assertEquals(actual, {
+      type: "null",
+      value: null,
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - number",
+  fn() {
+    const actual = valueToJSON(123);
+    assertEquals(actual, {
+      type: "number",
+      value: 123,
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - RegExp",
+  fn() {
+    const actual = valueToJSON(/match/);
+    assertEquals(actual, {
+      type: "RegExp",
+      value: "/match/",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - RegExp with flags",
+  fn() {
+    const actual = valueToJSON(/match/i);
+    assertEquals(actual, {
+      type: "RegExp",
+      value: "/match/i",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Set",
+  fn() {
+    const actual = valueToJSON(new Set([1, 2, 3]));
+    assertEquals(actual, {
+      type: "Set",
+      value: [
+        { type: "number", value: 1 },
+        { type: "number", value: 2 },
+        { type: "number", value: 3 },
+      ],
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - String",
+  fn() {
+    const actual = valueToJSON("a string");
+    assertEquals(actual, {
+      type: "string",
+      value: "a string",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Int8Array",
+  fn() {
+    const actual = valueToJSON(new Int8Array([1, 2, 3]));
+    assertEquals(actual, {
+      type: "Int8Array",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Uint8Array",
+  fn() {
+    const actual = valueToJSON(new Uint8Array([1, 2, 3]));
+    assertEquals(actual, {
+      type: "Uint8Array",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Uint8ClampedArray",
+  fn() {
+    const actual = valueToJSON(new Uint8ClampedArray([1, 2, 3]));
+    assertEquals(actual, {
+      type: "Uint8ClampedArray",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Int16Array",
+  fn() {
+    const actual = valueToJSON(new Int16Array([1, 2, 3, 4]));
+    assertEquals(actual, {
+      type: "Int16Array",
+      value: "AQACAAMABAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Uint16Array",
+  fn() {
+    const actual = valueToJSON(new Uint16Array([1, 2, 3, 4]));
+    assertEquals(actual, {
+      type: "Uint16Array",
+      value: "AQACAAMABAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Int32Array",
+  fn() {
+    const actual = valueToJSON(new Int32Array([1, 2, 3, 4]));
+    assertEquals(actual, {
+      type: "Int32Array",
+      value: "AQAAAAIAAAADAAAABAAAAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Uint32Array",
+  fn() {
+    const actual = valueToJSON(new Uint32Array([1, 2, 3, 4]));
+    assertEquals(actual, {
+      type: "Uint32Array",
+      value: "AQAAAAIAAAADAAAABAAAAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Float32Array",
+  fn() {
+    const actual = valueToJSON(new Float32Array([1.2, 3.4, 5.6]));
+    assertEquals(actual, {
+      type: "Float32Array",
+      value: "mpmZP5qZWUAzM7NA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - Float64Array",
+  fn() {
+    const actual = valueToJSON(new Float64Array([1.2, 3.4, 5.6]));
+    assertEquals(actual, {
+      type: "Float64Array",
+      value: "MzMzMzMz8z8zMzMzMzMLQGZmZmZmZhZA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - BigInt64Array",
+  fn() {
+    const actual = valueToJSON(new BigInt64Array([1n, 2n, 3n]));
+    assertEquals(actual, {
+      type: "BigInt64Array",
+      value: "AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - BigUint64Array",
+  fn() {
+    const actual = valueToJSON(new BigUint64Array([1n, 2n, 3n]));
+    assertEquals(actual, {
+      type: "BigUint64Array",
+      value: "AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - undefined",
+  fn() {
+    const actual = valueToJSON(undefined);
+    assertEquals(actual, {
+      type: "undefined",
+    });
+  },
+});
+
+Deno.test({
+  name: "valueToJSON - object",
+  fn() {
+    const actual = valueToJSON({ key: "value" });
+    assertEquals(actual, {
+      type: "object",
+      value: { key: { type: "string", value: "value" } },
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - Uint8Array",
+  fn() {
+    const actual = keyPartToJSON(new Uint8Array([1, 2, 3]));
+    assertEquals(actual, {
+      type: "Uint8Array",
+      value: "AQID",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - string",
+  fn() {
+    const actual = keyPartToJSON("a");
+    assertEquals(actual, {
+      type: "string",
+      value: "a",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - number",
+  fn() {
+    const actual = keyPartToJSON(1);
+    assertEquals(actual, {
+      type: "number",
+      value: 1,
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - number - Infinity",
+  fn() {
+    const actual = JSON.parse(JSON.stringify(keyPartToJSON(Infinity)));
+    assertEquals(actual, {
+      type: "number",
+      value: "Infinity",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - number - -Infinity",
+  fn() {
+    const actual = JSON.parse(JSON.stringify(keyPartToJSON(-Infinity)));
+    assertEquals(actual, {
+      type: "number",
+      value: "-Infinity",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - number - NaN",
+  fn() {
+    const actual = JSON.parse(JSON.stringify(keyPartToJSON(NaN)));
+    assertEquals(actual, {
+      type: "number",
+      value: "NaN",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - bigint",
+  fn() {
+    const actual = keyPartToJSON(100n);
+    assertEquals(actual, {
+      type: "bigint",
+      value: "100",
+    });
+  },
+});
+
+Deno.test({
+  name: "keyPartToJSON - boolean",
+  fn() {
+    const actual = keyPartToJSON(true);
+    assertEquals(actual, {
+      type: "boolean",
+      value: true,
+    });
+  },
+});
+
+Deno.test({
+  name: "keyToJSON",
+  fn() {
+    const actual = keyToJSON(["a", 1, 100n]);
+    assertEquals(actual, [
+      { type: "string", value: "a" },
+      { type: "number", value: 1 },
+      { type: "bigint", value: "100" },
+    ]);
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - bigint",
+  fn() {
+    const actual = toKeyPart({ type: "bigint", value: "100" });
+    assertEquals(actual, 100n);
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - boolean",
+  fn() {
+    const actual = toKeyPart({ type: "boolean", value: true });
+    assertEquals(actual, true);
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - number",
+  fn() {
+    const actual = toKeyPart({ type: "number", value: 100 });
+    assertEquals(actual, 100);
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - number - Infinity",
+  fn() {
+    assertStrictEquals(
+      toKeyPart({ type: "number", value: "Infinity" }),
+      Infinity,
+    );
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - number - -Infinity",
+  fn() {
+    assertStrictEquals(
+      toKeyPart({ type: "number", value: "-Infinity" }),
+      -Infinity,
+    );
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - number - NaN",
+  fn() {
+    const actual = toKeyPart({ type: "number", value: "NaN" });
+    assert(Number.isNaN(actual));
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - string",
+  fn() {
+    const actual = toKeyPart({ type: "string", value: "a string" });
+    assertEquals(actual, "a string");
+  },
+});
+
+Deno.test({
+  name: "toKeyPart - Uint8Array",
+  fn() {
+    const actual = toKeyPart({ type: "Uint8Array", value: "AQID" });
+    assert(timingSafeEqual(actual, new Uint8Array([1, 2, 3])));
+  },
+});
+
+Deno.test({
+  name: "toKey",
+  fn() {
+    const actual = toKey([
+      { type: "string", value: "a" },
+      { type: "number", value: 1 },
+      { type: "bigint", value: "100" },
+    ]);
+    assertEquals(actual, ["a", 1, 100n]);
+  },
+});
+
+Deno.test({
+  name: "toEntry",
+  fn() {
+    const actual = toEntry({
+      key: [{ type: "string", value: "a" }],
+      value: {
+        type: "Array",
+        value: [
+          { type: "number", value: 1 },
+          { type: "number", value: 2 },
+          { type: "number", value: 3 },
+        ],
+      },
+      versionstamp: "00000000",
+    });
+    assertEquals(actual, {
+      key: ["a"],
+      value: [1, 2, 3],
+      versionstamp: "00000000",
+    });
+  },
+});
+
+Deno.test({
+  name: "toEntryMaybe - entry",
+  fn() {
+    const actual = toEntryMaybe({
+      key: [{ type: "string", value: "a" }],
+      value: {
+        type: "Array",
+        value: [
+          { type: "number", value: 1 },
+          { type: "number", value: 2 },
+          { type: "number", value: 3 },
+        ],
+      },
+      versionstamp: "00000000",
+    });
+    assertEquals(actual, {
+      key: ["a"],
+      value: [1, 2, 3],
+      versionstamp: "00000000",
+    });
+  },
+});
+
+Deno.test({
+  name: "toEntryMaybe - no entry",
+  fn() {
+    const actual = toEntryMaybe({
+      key: [{ type: "string", value: "a" }],
+      value: null,
+      versionstamp: null,
+    });
+    assertEquals(actual, {
+      key: ["a"],
+      value: null,
+      versionstamp: null,
+    });
+  },
+});
+
+Deno.test({
+  name: "entryToJSON",
+  fn() {
+    const actual = entryToJSON({
+      key: ["a"],
+      value: [1, 2, 3],
+      versionstamp: "00000000",
+    });
+    assertEquals(actual, {
+      key: [{ type: "string", value: "a" }],
+      value: {
+        type: "Array",
+        value: [
+          { type: "number", value: 1 },
+          { type: "number", value: 2 },
+          { type: "number", value: 3 },
+        ],
+      },
+      versionstamp: "00000000",
+    });
+  },
+});
+
+Deno.test({
+  name: "toEntry - entry",
+  fn() {
+    const actual = entryMaybeToJSON({
+      key: ["a"],
+      value: [1, 2, 3],
+      versionstamp: "00000000",
+    });
+    assertEquals(actual, {
+      key: [{ type: "string", value: "a" }],
+      value: {
+        type: "Array",
+        value: [
+          { type: "number", value: 1 },
+          { type: "number", value: 2 },
+          { type: "number", value: 3 },
+        ],
+      },
+      versionstamp: "00000000",
+    });
+  },
+});
+
+Deno.test({
+  name: "toEntry - no entry",
+  fn() {
+    const actual = entryMaybeToJSON({
+      key: ["a"],
+      value: null,
+      versionstamp: null,
+    });
+    assertEquals(actual, {
+      key: [{ type: "string", value: "a" }],
+      value: null,
+      versionstamp: null,
+    });
+  },
+});

--- a/json.ts
+++ b/json.ts
@@ -381,7 +381,7 @@ export interface KvSetJSON {
 }
 
 /** Used internally to identify a typed array. */
-export type TypedArray =
+type TypedArray =
   | Int8Array
   | Uint8Array
   | Uint8ClampedArray
@@ -398,7 +398,7 @@ export type TypedArray =
  * Used internally to be able to map the name of the typed array to its instance
  * type.
  */
-export interface TypedArrayMap {
+interface TypedArrayMap {
   /** {@linkcode Int8Array} which is a typed array. */
   Int8Array: Int8Array;
   /** {@linkcode Uint8Array} which is a typed array. */
@@ -424,7 +424,7 @@ export interface TypedArrayMap {
 }
 
 /** Used internally. The string literal types of the names of the type. */
-export type TypedArrayTypes = keyof TypedArrayMap;
+type TypedArrayTypes = keyof TypedArrayMap;
 
 /**
  * A representation of a typed array Deno KV value. The value is a URL safe

--- a/json.ts
+++ b/json.ts
@@ -1,0 +1,1856 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Utilities for handling Deno KV entries, keys, and values as structures
+ * which can be serialized and deserialized to JSON.
+ *
+ * This is useful when communicating entries and values outside of the runtime
+ * environment.
+ *
+ * @example Converting to a maybe entry to JSON
+ *
+ * ```ts
+ * import { entryMaybeToJSON } from "@deno/kv-utils/json";
+ *
+ * const db = await Deno.openKv();
+ * const entryMaybe = await db.get(["a"]);
+ *
+ * // `json` is now an object which can be safely converted to a JSON string
+ * const json = entryMaybeToJSON(entryMaybe);
+ * db.close();
+ * ```
+ *
+ * @example Converting a JSON value to a Deno KV value
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ *
+ * // `json` represents a `Uint8Array` with the bytes of [1, 2, 3]
+ * const json = { type: "Uint8Array", value: "AQID" } as const;
+ *
+ * const db = await Deno.openKv();
+ * await db.set(["a"], toValue(json));
+ * db.close();
+ * ```
+ *
+ * @module
+ */
+
+import { decodeBase64Url, encodeBase64Url } from "@std/encoding/base64url";
+
+// Deno KV Key types
+
+/**
+ * A JSON representation of a {@linkcode bigint} Deno KV key part. The value
+ * is a string representation of the integer, for example `100n` would be:
+ *
+ * ```json
+ * { "type": "bigint", "value": "100" }
+ * ```
+ */
+export interface KvBigIntJSON {
+  /**
+   * The type of the key part, which is always `"bigint"`.
+   */
+  type: "bigint";
+  /**
+   * The string representation of the bigint value.
+   */
+  value: string;
+}
+
+/**
+ * A JSON representation of a {@linkcode boolean} Deno KV key part. The value
+ * is the boolean value, for example `true` would be:
+ *
+ * ```json
+ * { "type": "boolean", "value": true }
+ * ```
+ */
+export interface KvBooleanJSON {
+  /**
+   * The type of the key part, which is always `"boolean"`.
+   */
+  type: "boolean";
+  /**
+   * The boolean value.
+   */
+  value: boolean;
+}
+
+/**
+ * A JSON representation of a {@linkcode number} Deno KV key part. The value
+ * is the number value, for example `100` would be:
+ *
+ * ```json
+ * { "type": "number", "value": 100 }
+ * ```
+ *
+ * For special numbers, the value is a string representation of the number, for
+ * example `Infinity` would be:
+ *
+ * ```json
+ * { "type": "number", "value": "Infinity" }
+ * ```
+ */
+export interface KvNumberJSON {
+  /**
+   * The type of the key part, which is always `"number"`.
+   */
+  type: "number";
+  /**
+   * The number value.
+   */
+  value: number | "Infinity" | "-Infinity" | "NaN";
+}
+
+/**
+ * A JSON representation of a {@linkcode string} Deno KV key part. The value is
+ * the string value, for example `"value"` would be:
+ *
+ * ```json
+ * { "type": "string", "value": "value" }
+ * ```
+ */
+export interface KvStringJSON {
+  /**
+   * The type of the key part, which is always `"string"`.
+   */
+  type: "string";
+  /**
+   * The string value.
+   */
+  value: string;
+}
+
+/**
+ * A JSON representation of a {@linkcode Uint8Array} Deno KV key part. The value
+ * is a URL safe base64 encoded value, for example an array with the values of
+ * `[ 1, 2, 3 ]` would be:
+ *
+ * ```json
+ * { "type": "Uint8Array", "value": "AQID" }
+ * ```
+ *
+ * While Deno KV accepts anything that is array view like as a key part, when
+ * the value is read as part of an entry, it is always represented as a
+ * `Uint8Array`.
+ */
+export interface KvUint8ArrayJSON {
+  /**
+   * The type of the key part, which is always `"Uint8Array"`.
+   */
+  type: "Uint8Array";
+  /**
+   * The URL safe base64 encoded value of the array.
+   */
+  value: string;
+}
+
+/**
+ * JSON representations of {@linkcode Deno.KvKeyPart}. This represents each key
+ * part type that is supported by Deno KV.
+ */
+export type KvKeyPartJSON =
+  | KvBigIntJSON
+  | KvBooleanJSON
+  | KvNumberJSON
+  | KvStringJSON
+  | KvUint8ArrayJSON;
+
+/**
+ * A JSON representation of a {@linkcode Deno.KvKey}, which is an array of
+ * {@linkcode KvKeyPartJSON} items.
+ */
+export type KvKeyJSON = readonly KvKeyPartJSON[];
+
+// Deno KV Value types
+
+/**
+ * A representation of an {@linkcode ArrayBuffer} Deno KV value. The value is
+ * the bytes of the array buffer encoded as a URL safe base64 string, for
+ * example an array buffer with the byte values of `[ 1, 2, 3 ]` would be:
+ *
+ * ```json
+ * { "type": "ArrayBuffer", "value": "AQID" }
+ * ```
+ */
+export interface KvArrayBufferJSON {
+  /**
+   * The type of the value, which is always `"ArrayBuffer"`.
+   */
+  type: "ArrayBuffer";
+  /**
+   * The URL safe base64 encoded value of the array buffer.
+   */
+  value: string;
+}
+
+/**
+ * A representation of an {@linkcode Array} Deno KV value. The value is the
+ * JSON serialized version of the elements of the array.
+ */
+export interface KvArrayJSON {
+  /**
+   * The type of the value, which is always `"Array"`.
+   */
+  type: "Array";
+  /**
+   * The JSON serialized version of the array.
+   */
+  value: readonly KvValueJSON[];
+}
+
+/**
+ * A representation of an {@linkcode DataView} Deno KV value. The value is
+ * the bytes of the buffer encoded as a URL safe base64 string, for example a
+ * data view with the byte values of `[ 1, 2, 3 ]` would be:
+ *
+ * ```json
+ * { "type": "DataView", "value": "AQID" }
+ * ```
+ */
+export interface KvDataViewJSON {
+  /**
+   * The type of the value, which is always `"DataView"`.
+   */
+  type: "DataView";
+  /**
+   * The URL safe base64 encoded value of the data view.
+   */
+  value: string;
+}
+
+/**
+ * A representation of a {@linkcode Date} Deno KV value. The value is the
+ * [ISO string representation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+ * of the date.
+ */
+export interface KvDateJSON {
+  /**
+   * The type of the value, which is always `"Date"`.
+   */
+  type: "Date";
+  /**
+   * The ISO string representation of the date.
+   */
+  value: string;
+}
+
+/**
+ * Error instances which are
+ * [cloneable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#error_types)
+ * and therefore can be stored in a Deno KV store.
+ *
+ * This type is used to allow type inference when deserializing from JSON.
+ */
+export interface CloneableErrors {
+  /** {@linkcode Error} which is cloneable. */
+  Error: Error;
+  /** {@linkcode EvalError} which is cloneable. */
+  EvalError: EvalError;
+  /** {@linkcode RangeError} which is cloneable. */
+  RangeError: RangeError;
+  /** {@linkcode ReferenceError} which is cloneable. */
+  ReferenceError: ReferenceError;
+  /** {@linkcode SyntaxError} which is cloneable. */
+  SyntaxError: SyntaxError;
+  /** {@linkcode TypeError} which is cloneable. */
+  TypeError: TypeError;
+  /** {@linkcode URIError} which is cloneable. */
+  URIError: URIError;
+}
+
+/**
+ * The keys of {@linkcode CloneableErrors} which is used for type inference
+ * when deserializing from JSON.
+ */
+export type CloneableErrorTypes = keyof CloneableErrors;
+
+/**
+ * A representation of {@linkcode Error}s that can be stored as Deno KV values.
+ * The value is set to a serialized version of the value. Instances that are
+ * not one of the specified types, but inherit from `Error` will be serialized
+ * as `Error`.
+ */
+export interface KvErrorJSON<
+  ErrorType extends CloneableErrorTypes = CloneableErrorTypes,
+> {
+  /**
+   * The type of the error, which is one of the cloneable error types.
+   */
+  type: ErrorType;
+  /**
+   * The value of the error, which is a JSON serialized version of the error.
+   */
+  value: {
+    message: string;
+    cause?: KvValueJSON | undefined;
+    stack?: string | undefined;
+  };
+}
+
+/**
+ * A representation of a {@linkcode Deno.KvU64} value. The value is the string
+ * representation of the unsigned integer.
+ */
+export interface KvKvU64JSON {
+  /**
+   * The type of the value, which is always `"KvU64"`.
+   */
+  type: "KvU64";
+  /**
+   * The string representation of the unsigned integer value.
+   */
+  value: string;
+}
+
+/**
+ * A representation of a {@linkcode Map} Deno KV value. The value is an array
+ * of map entries where is map entry is a tuple of a JSON serialized key and
+ * value.
+ */
+export interface KvMapJSON {
+  /**
+   * The type of the value, which is always `"Map"`.
+   */
+  type: "Map";
+  /**
+   * The JSON serialized version of the map entries.
+   */
+  value: readonly [key: KvValueJSON, value: KvValueJSON][];
+}
+
+/**
+ * A representation of a {@linkcode null} Deno KV value. The value is `null`.
+ */
+export interface KvNullJSON {
+  /**
+   * The type of the value, which is always `"null"`.
+   */
+  type: "null";
+  /**
+   * The value of the value, which is always `null`.
+   */
+  value: null;
+}
+
+/**
+ * A representation of a {@linkcode object} Deno KV value. The value is a JSON
+ * serialized version of the value.
+ */
+export interface KvObjectJSON {
+  /**
+   * The type of the value, which is always `"object"`.
+   */
+  type: "object";
+  /**
+   * The JSON serialized version of the object.
+   */
+  value: { [key: string]: KvValueJSON };
+}
+
+/**
+ * A representation of a {@linkcode RegExp} Deno KV value. The value is a string
+ * representation of the regular expression value.
+ */
+export interface KvRegExpJSON {
+  /**
+   * The type of the value, which is always `"RegExp"`.
+   */
+  type: "RegExp";
+  /**
+   * The string representation of the regular expression value.
+   */
+  value: string;
+}
+
+/**
+ * A representation of a {@linkcode Set} Deno KV value. The value is an array
+ * of the JSON serialized values of the set.
+ */
+export interface KvSetJSON {
+  /**
+   * The type of the value, which is always `"Set"`.
+   */
+  type: "Set";
+  /**
+   * The JSON serialized version of the set values.
+   */
+  value: readonly KvValueJSON[];
+}
+
+/** Used internally to identify a typed array. */
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
+
+/**
+ * Used internally to be able to map the name of the typed array to its instance
+ * type.
+ */
+export interface TypedArrayMap {
+  /** {@linkcode Int8Array} which is a typed array. */
+  Int8Array: Int8Array;
+  /** {@linkcode Uint8Array} which is a typed array. */
+  Uint8Array: Uint8Array;
+  /** {@linkcode Uint8ClampedArray} which is a typed array. */
+  Uint8ClampedArray: Uint8ClampedArray;
+  /** {@linkcode Int16Array} which is a typed array. */
+  Int16Array: Int16Array;
+  /** {@linkcode Uint16Array} which is a typed array. */
+  Uint16Array: Uint16Array;
+  /** {@linkcode Int32Array} which is a typed array. */
+  Int32Array: Int32Array;
+  /** {@linkcode Uint32Array} which is a typed array. */
+  Uint32Array: Uint32Array;
+  /** {@linkcode Float32Array} which is a typed array. */
+  Float32Array: Float32Array;
+  /** {@linkcode Float64Array} which is a typed array. */
+  Float64Array: Float64Array;
+  /** {@linkcode BigInt64Array} which is a typed array. */
+  BigInt64Array: BigInt64Array;
+  /** {@linkcode BigUint64Array} which is a typed array. */
+  BigUint64Array: BigUint64Array;
+}
+
+/** Used internally. The string literal types of the names of the type. */
+export type TypedArrayTypes = keyof TypedArrayMap;
+
+/**
+ * A representation of a typed array Deno KV value. The value is a URL safe
+ * base64 encoded string which represents the individual bytes of the array.
+ */
+export interface KvTypedArrayJSON<
+  ArrayType extends TypedArrayTypes = TypedArrayTypes,
+> {
+  /**
+   * The type of the value.
+   */
+  type: ArrayType;
+  /**
+   * The URL safe base64 encoded value of the typed array.
+   */
+  value: string;
+}
+
+/**
+ * A representation of a {@linkcode undefined} Deno KV value. The value is
+ * undefined, and therefore elided when serialized. Therefore there is only one
+ * form of this entity:
+ *
+ * ```json
+ * { "type": "undefined" }
+ * ```
+ */
+export interface KvUndefinedJSON {
+  /**
+   * The type of the value, which is always `"undefined"`.
+   */
+  type: "undefined";
+}
+
+/**
+ * JSON representations of {@linkcode Deno.Kv} values, where the value types are
+ * exhaustive of what Deno KV supports and are allowed via
+ * [structured cloning](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+ */
+export type KvValueJSON =
+  | KvArrayBufferJSON
+  | KvArrayJSON
+  | KvBigIntJSON
+  | KvBooleanJSON
+  | KvDataViewJSON
+  | KvDateJSON
+  | KvErrorJSON
+  | KvKvU64JSON
+  | KvMapJSON
+  | KvNullJSON
+  | KvNumberJSON
+  | KvObjectJSON
+  | KvRegExpJSON
+  | KvSetJSON
+  | KvStringJSON
+  | KvTypedArrayJSON
+  | KvUndefinedJSON;
+
+// Deno KV Entry types
+
+/**
+ * A representation of a {@linkcode Deno.KvEntry} where the key and value are
+ * encoded in a JSON serializable format.
+ */
+export interface KvEntryJSON {
+  /**
+   * The key of the entry.
+   */
+  key: KvKeyJSON;
+  /**
+   * The value of the entry.
+   */
+  value: KvValueJSON;
+  /**
+   * The versionstamp of the entry.
+   */
+  versionstamp: string;
+}
+
+/**
+ * A representation of a {@linkcode Deno.KvEntryMaybe} where the key and value
+ * are encoded in a JSON serializable format.
+ */
+export type KvEntryMaybeJSON = KvEntryJSON | {
+  /**
+   * The key of the entry.
+   */
+  key: KvKeyJSON;
+  /**
+   * The value of the entry.
+   */
+  value: null;
+  /**
+   * The versionstamp of the entry.
+   */
+  versionstamp: null;
+};
+
+// Serializing to JSON
+
+/**
+ * Internal function to serialize various classes of errors to JSON.
+ *
+ * @param error The error to serialize.
+ * @returns The JSON representation of the error.
+ *
+ * @private
+ */
+function errorToJSON(error: Error): KvErrorJSON {
+  const { message, stack, cause } = error;
+  const value: KvErrorJSON["value"] = { message };
+  if (cause) {
+    value.cause = valueToJSON(cause);
+  }
+  if (stack) {
+    value.stack = stack;
+  }
+  if (error instanceof EvalError) {
+    return { type: "EvalError", value };
+  }
+  if (error instanceof RangeError) {
+    return { type: "RangeError", value };
+  }
+  if (error instanceof ReferenceError) {
+    return { type: "ReferenceError", value };
+  }
+  if (error instanceof SyntaxError) {
+    return { type: "SyntaxError", value };
+  }
+  if (error instanceof TypeError) {
+    return { type: "TypeError", value };
+  }
+  if (error instanceof URIError) {
+    return { type: "URIError", value };
+  }
+  return { type: "Error", value };
+}
+
+/**
+ * Internal function to serialize various typed arrays to JSON.
+ *
+ * @param typedArray The typed array to serialize.
+ * @returns The JSON representation of the typed array.
+ *
+ * @private
+ */
+function typedArrayToJSON(typedArray: ArrayBufferView): KvTypedArrayJSON {
+  const value = encodeBase64Url(typedArray.buffer);
+  if (typedArray instanceof Int8Array) {
+    return { type: "Int8Array", value };
+  }
+  if (typedArray instanceof Uint8Array) {
+    return { type: "Uint8Array", value };
+  }
+  if (typedArray instanceof Uint8ClampedArray) {
+    return { type: "Uint8ClampedArray", value };
+  }
+  if (typedArray instanceof Int16Array) {
+    return { type: "Int16Array", value };
+  }
+  if (typedArray instanceof Uint16Array) {
+    return { type: "Uint16Array", value };
+  }
+  if (typedArray instanceof Int32Array) {
+    return { type: "Int32Array", value };
+  }
+  if (typedArray instanceof Uint32Array) {
+    return { type: "Uint32Array", value };
+  }
+  if (typedArray instanceof Float32Array) {
+    return { type: "Float32Array", value };
+  }
+  if (typedArray instanceof Float64Array) {
+    return { type: "Float64Array", value };
+  }
+  if (typedArray instanceof BigInt64Array) {
+    return { type: "BigInt64Array", value };
+  }
+  if (typedArray instanceof BigUint64Array) {
+    return { type: "BigUint64Array", value };
+  }
+  throw TypeError("Unexpected typed array type, could not serialize.");
+}
+
+/**
+ * Internal function to encode an object.
+ *
+ * @param object The object to encode.
+ * @returns The encoded object.
+ *
+ * @private
+ */
+function encodeObject(object: object): { [key: string]: KvValueJSON } {
+  const result: { [key: string]: KvValueJSON } = {};
+  for (const [key, value] of Object.entries(object)) {
+    result[key] = valueToJSON(value);
+  }
+  return result;
+}
+
+/**
+ * Internal function to decode an object.
+ *
+ * @param json The JSON object to decode.
+ * @returns The decoded object.
+ *
+ * @private
+ */
+function decodeObject(json: { [key: string]: KvValueJSON }): object {
+  const result: { [key: string]: unknown } = {};
+  for (const [key, value] of Object.entries(json)) {
+    result[key] = toValue(value);
+  }
+  return result;
+}
+
+/**
+ * Serialize a {@linkcode Deno.KvKeyPart} to JSON.
+ *
+ * @param value The key part to serialize.
+ * @returns The JSON representation of the key part.
+ * @example Serialize a key part to JSON
+ *
+ * ```ts
+ * import { keyPartToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const keyPart = 100n;
+ * const json = keyPartToJSON(keyPart);
+ * assertEquals(json, { type: "bigint", value: "100" });
+ * ```
+ */
+export function keyPartToJSON(value: Deno.KvKeyPart): KvKeyPartJSON {
+  switch (typeof value) {
+    case "bigint":
+      return { type: "bigint", value: String(value) };
+    case "boolean":
+      return { type: "boolean", value };
+    case "number":
+      if (Number.isNaN(value)) {
+        return { type: "number", value: "NaN" };
+      } else if (value === Infinity) {
+        return { type: "number", value: "Infinity" };
+      } else if (value === -Infinity) {
+        return { type: "number", value: "-Infinity" };
+      }
+      return { type: "number", value };
+    case "object":
+      if (value instanceof Uint8Array) {
+        return { type: "Uint8Array", value: encodeBase64Url(value) };
+      }
+      break;
+    case "string":
+      return { type: "string", value };
+  }
+  throw new TypeError("Unable to serialize value.");
+}
+
+/**
+ * Serialize a {@linkcode Deno.KvKey} to JSON.
+ *
+ * @param value The key to serialize.
+ * @returns The JSON representation of the key.
+ * @example Serialize a key to JSON
+ *
+ * ```ts
+ * import { keyToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const key = ["a", 100n];
+ * const json = keyToJSON(key);
+ * assertEquals(json, [
+ *   { type: "string", value: "a" },
+ *   { type: "bigint", value: "100" },
+ * ]);
+ * ```
+ */
+export function keyToJSON(value: Deno.KvKey): KvKeyJSON {
+  return value.map(keyPartToJSON);
+}
+
+/**
+ * Serialize an array that can be stored in Deno KV to JSON.
+ *
+ * @param value The array value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = valueToJSON([["a", 1], ["b", 2]]);
+ * assertEquals(json, { type: "Array", value: [
+ *   { type: "Array", value: [{ type: "string", value: "a" }, { type: "number", value: 1 }] },
+ *   { type: "Array", value: [{ type: "string", value: "b" }, { type: "number", value: 2 }] },
+ * ] });
+ * ```
+ */
+export function valueToJSON(value: unknown[]): KvArrayJSON;
+/**
+ * Serialize a bigint that can be stored in Deno KV to JSON.
+ *
+ * @param value The bigint value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = 100n;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "bigint", value: "100" });
+ * ```
+ */
+export function valueToJSON(value: bigint): KvBigIntJSON;
+/**
+ * Serialize a boolean that can be stored in Deno KV to JSON.
+ *
+ * @param value The boolean value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = true;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "boolean", value: true });
+ * ```
+ */
+export function valueToJSON(value: boolean): KvBooleanJSON;
+/**
+ * Serialize a {@linkcode Date} that can be stored in Deno KV to JSON.
+ *
+ * @param value The date value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Date();
+ * const json = valueToJSON(value);
+ * assertEquals(json.type, "Date");
+ * ```
+ */
+export function valueToJSON(value: Date): KvDateJSON;
+/**
+ * Serialize an error that can be stored in Deno KV to JSON.
+ *
+ * @typeParam ErrorType The type of error that can be serialized
+ * @param value The error value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new TypeError("That is the wrong type!");
+ * const json = valueToJSON(value);
+ * assertEquals(json, {
+ *   type: "TypeError",
+ *   value: { message: "That is the wrong type!", stack: value.stack },
+ * });
+ * ```
+ */
+export function valueToJSON<ErrorType extends CloneableErrorTypes>(
+  value: Error,
+): KvErrorJSON<ErrorType>;
+/**
+ * Serialize a {@linkcode Deno.KvU64} that can be stored in Deno KV to JSON.
+ *
+ * @param value The value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Deno.KvU64(100n);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "KvU64", value: "100" });
+ * ```
+ */
+export function valueToJSON(value: Deno.KvU64): KvKvU64JSON;
+/**
+ * Serialize a {@linkcode Map} that can be stored in Deno KV to JSON.
+ *
+ * @param value The map value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Map([["a", 1], ["b", 2]]);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "Map", value: [
+ *   [{ type: "string", value: "a" }, { type: "number", value: 1 }],
+ *   [{ type: "string", value: "b" }, { type: "number", value: 2 }],
+ * ] });
+ * ```
+ */
+export function valueToJSON(value: Map<unknown, unknown>): KvMapJSON;
+/**
+ * Serialize a `null` that can be stored in Deno KV to JSON.
+ *
+ * @param value The value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = null;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "null", value: null });
+ * ```
+ */
+export function valueToJSON(value: null): KvNullJSON;
+/**
+ * Serialize a number that can be stored in Deno KV to JSON.
+ *
+ * This includes special numbers like `Infinity`, `-Infinity`, and `NaN`.
+ *
+ * @param value The number value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = 100;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "number", value: 100 });
+ * ```
+ */
+export function valueToJSON(value: number): KvNumberJSON;
+/**
+ * Serialize a {@linkcode RegExp} that can be stored in Deno KV to JSON.
+ *
+ * @param value The regex value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = /1234/i;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "RegExp", value: "/1234/i" });
+ * ```
+ */
+export function valueToJSON(value: RegExp): KvRegExpJSON;
+/**
+ * Serialize a {@linkcode Set} that can be stored in Deno KV to JSON.
+ *
+ * @param value The set value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Set([1, 2, 3]);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "Set", value: [
+ *   { type: "number", value: 1 },
+ *   { type: "number", value: 2 },
+ *   { type: "number", value: 3 },
+ * ] });
+ * ```
+ */
+export function valueToJSON(value: Set<unknown>): KvSetJSON;
+/**
+ * Serialize a string that can be stored in Deno KV to JSON.
+ *
+ * @param value The string value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = "hello, world!";
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "string", value: "hello, world!" });
+ * ```
+ */
+export function valueToJSON(value: string): KvStringJSON;
+/**
+ * Serialize a typed array that can be stored in Deno KV to JSON.
+ *
+ * @typeParam TA The type of the typed array, which is inferred from the value
+ * @param value The typed array value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Uint8Array([1, 2, 3]);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "Uint8Array", value: "AQID" });
+ * ```
+ */
+export function valueToJSON<TA extends TypedArray>(
+  value: TA,
+): KvTypedArrayJSON<TA[typeof Symbol.toStringTag]>;
+/**
+ * Serialize an {@linkcode ArrayBuffer} that can be stored in Deno KV to JSON.
+ *
+ * @param value The array buffer value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Uint8Array([1, 2, 3]).buffer;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "ArrayBuffer", value: "AQID" });
+ * ```
+ */
+export function valueToJSON(value: ArrayBufferLike): KvArrayBufferJSON;
+/**
+ * Serialize a {@linkcode DataView} that can be stored in Deno KV to JSON.
+ *
+ * @param value The data view value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new DataView(new Uint8Array([1, 2, 3]).buffer);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "DataView", value: "AQID" });
+ * ```
+ */
+export function valueToJSON(value: DataView): KvDataViewJSON;
+/**
+ * Serialize an `undefined` value that can be stored in Deno KV to JSON.
+ *
+ * @param value The `undefined` value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = undefined;
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "undefined" });
+ * ```
+ */
+export function valueToJSON(value: undefined): KvUndefinedJSON;
+/**
+ * Serialize an object value that can be stored in Deno KV to JSON.
+ *
+ * @param value The object to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = { a: 1, b: 2 };
+ * const json = valueToJSON(value);
+ * assertEquals(json, {
+ *   type: "object",
+ *   value: {
+ *     a: { type: "number", value: 1 },
+ *     b: { type: "number", value: 2 },
+ *   }
+ * });
+ * ```
+ */
+export function valueToJSON(value: object): KvObjectJSON;
+/**
+ * Serialize a value that can be stored in Deno KV to JSON.
+ *
+ * @param value The value to serialize
+ * @returns The JSON representation of the value
+ * @example Serialize a value to JSON
+ *
+ * ```ts
+ * import { valueToJSON } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = new Map([["a", 1], ["b", 2]]);
+ * const json = valueToJSON(value);
+ * assertEquals(json, { type: "Map", value: [
+ *  [{ type: "string", value: "a" }, { type: "number", value: 1 }],
+ *  [{ type: "string", value: "b" }, { type: "number", value: 2 }],
+ * ] });
+ * ```
+ */
+export function valueToJSON(value: unknown): KvValueJSON;
+export function valueToJSON(value: unknown): KvValueJSON {
+  switch (typeof value) {
+    case "bigint":
+    case "boolean":
+    case "number":
+    case "string":
+      return keyPartToJSON(value);
+    case "undefined":
+      return { type: "undefined" };
+    case "object":
+      if (Array.isArray(value)) {
+        return { type: "Array", value: value.map(valueToJSON) };
+      }
+      if (value instanceof DataView) {
+        return { type: "DataView", value: encodeBase64Url(value.buffer) };
+      }
+      if (ArrayBuffer.isView(value)) {
+        return typedArrayToJSON(value);
+      }
+      if (value instanceof ArrayBuffer) {
+        return { type: "ArrayBuffer", value: encodeBase64Url(value) };
+      }
+      if (value instanceof Date) {
+        return { type: "Date", value: value.toJSON() };
+      }
+      if ("Deno" in globalThis && value instanceof Deno.KvU64) {
+        return { type: "KvU64", value: String(value) };
+      }
+      if (value instanceof Error) {
+        return errorToJSON(value);
+      }
+      if (value instanceof Map) {
+        const mapped: [KvValueJSON, KvValueJSON][] = [];
+        for (const [key, val] of value.entries()) {
+          mapped.push([valueToJSON(key), valueToJSON(val)]);
+        }
+        return { type: "Map", value: mapped };
+      }
+      if (value === null) {
+        return { type: "null", value };
+      }
+      if (value instanceof RegExp) {
+        return { type: "RegExp", value: String(value) };
+      }
+      if (value instanceof Set) {
+        return { type: "Set", value: [...value].map(valueToJSON) };
+      }
+      return { type: "object", value: encodeObject(value) };
+    default:
+      throw new TypeError("Unexpected value type, unable to serialize.");
+  }
+}
+
+/**
+ * Serialize a {@linkcode Deno.KvEntry} to JSON.
+ *
+ * @param entry The entry to serialize.
+ * @returns The JSON representation of the entry.
+ * @example Serialize an entry to JSON
+ *
+ * ```ts
+ * import { assert } from "@std/assert/assert";
+ * import { entryToJSON } from "@deno/kv-utils/json";
+ *
+ * const db = await Deno.openKv();
+ * const maybeEntry = await db.get(["a"]);
+ * assert(maybeEntry.versionstamp);
+ * const json = entryToJSON(maybeEntry);
+ * db.close();
+ * ```
+ */
+export function entryToJSON(
+  { key, value, versionstamp }: Deno.KvEntry<unknown>,
+): KvEntryJSON {
+  return {
+    key: key.map(keyPartToJSON),
+    value: valueToJSON(value),
+    versionstamp,
+  };
+}
+
+/**
+ * Serialize a {@linkcode Deno.KvEntryMaybe} to JSON.
+ *
+ * @param entryMaybe The maybe entry to serialize.
+ * @returns The JSON representation of the maybe entry.
+ * @example Serialize a maybe entry to JSON as a response
+ *
+ * ```ts ignore
+ * import { entryMaybeToJSON } from "@deno/kv-utils";
+ *
+ * const db = await Deno.openKv();
+ *
+ * Deno.serve(async (_req) => {
+ *   const maybeEntry = await db.get(["a"]);
+ *   const json = entryMaybeToJSON(maybeEntry);
+ *   return Response.json(json);
+ * });
+ * ```
+ */
+export function entryMaybeToJSON(
+  entryMaybe: Deno.KvEntryMaybe<unknown>,
+): KvEntryMaybeJSON {
+  const { key, value, versionstamp } = entryMaybe;
+  return {
+    key: key.map(keyPartToJSON),
+    value: value === null && versionstamp === null ? null : valueToJSON(value),
+    versionstamp,
+  } as KvEntryMaybeJSON;
+}
+
+// Deserializing from JSON
+
+/**
+ * Internal function to deserialize an error.
+ *
+ * @param param0 The JSON representation of the value.
+ * @returns The deserialized error.
+ * @private
+ */
+function toError(
+  { type, value: { message, stack, cause } }: KvErrorJSON,
+): Error {
+  let error: Error;
+  const options = cause ? { cause: toValue(cause) } : undefined;
+  switch (type) {
+    case "EvalError":
+      error = new EvalError(message, options);
+      break;
+    case "RangeError":
+      error = new RangeError(message, options);
+      break;
+    case "ReferenceError":
+      error = new ReferenceError(message, options);
+      break;
+    case "SyntaxError":
+      error = new SyntaxError(message, options);
+      break;
+    case "TypeError":
+      error = new TypeError(message, options);
+      break;
+    case "URIError":
+      error = new URIError(message, options);
+      break;
+    default:
+      error = new Error(message, options);
+  }
+  if (stack) {
+    Object.defineProperty(error, "stack", {
+      value: stack,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return error;
+}
+
+/**
+ * Internal function to deserialize typed arrays.
+ *
+ * @param json The JSON representation of the typed array.
+ * @returns The deserialized typed array.
+ * @private
+ */
+function toTypedArray(json: KvTypedArrayJSON): ArrayBufferView {
+  const u8 = decodeBase64Url(json.value);
+  switch (json.type) {
+    case "BigInt64Array":
+      return new BigInt64Array(u8.buffer);
+    case "BigUint64Array":
+      return new BigUint64Array(u8.buffer);
+    case "Float32Array":
+      return new Float32Array(u8.buffer);
+    case "Float64Array":
+      return new Float64Array(u8.buffer);
+    case "Int16Array":
+      return new Int16Array(u8.buffer);
+    case "Int32Array":
+      return new Int32Array(u8.buffer);
+    case "Int8Array":
+      return new Int8Array(u8.buffer);
+    case "Uint16Array":
+      return new Uint16Array(u8.buffer);
+    case "Uint32Array":
+      return new Uint32Array(u8.buffer);
+    case "Uint8Array":
+      return u8;
+    case "Uint8ClampedArray":
+      return new Uint8ClampedArray(u8.buffer);
+  }
+}
+
+/**
+ * Deserialize {@linkcode KvBigIntJSON} to a bigint.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "bigint", value: "100" } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, 100n);
+ * ```
+ */
+export function toKeyPart(json: KvBigIntJSON): bigint;
+/**
+ * Deserialize {@linkcode KvBooleanJSON} to a boolean.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "boolean", value: true } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, true);
+ * ```
+ */
+export function toKeyPart(json: KvBooleanJSON): boolean;
+/**
+ * Deserialize {@linkcode KvNumberJSON} to a number.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "number", value: 100 } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, 100);
+ * ```
+ */
+export function toKeyPart(json: KvNumberJSON): number;
+/**
+ * Deserialize {@linkcode KvStringJSON} to a string.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "string", value: "abc" } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, "abc");
+ * ```
+ */
+export function toKeyPart(json: KvStringJSON): string;
+/**
+ * Deserialize {@linkcode KvUint8ArrayJSON} to a {@linkcode Uint8Array}.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "Uint8Array", value: "AQID" } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, new Uint8Array([1, 2, 3]));
+ * ```
+ */
+export function toKeyPart(json: KvUint8ArrayJSON): Uint8Array;
+/**
+ * Deserialize {@linkcode KvKeyPartJSON} to a {@linkcode Deno.KvKeyPart}.
+ *
+ * @param json The JSON representation of the key part.
+ * @returns The deserialized key part.
+ * @example Deserialize a key part from JSON
+ *
+ * ```ts
+ * import { toKeyPart } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "bigint", value: "100" } as const;
+ * const keyPart = toKeyPart(json);
+ * assertEquals(keyPart, 100n);
+ * ```
+ */
+export function toKeyPart(json: KvKeyPartJSON): Deno.KvKeyPart;
+export function toKeyPart(json: KvKeyPartJSON): Deno.KvKeyPart {
+  switch (json.type) {
+    case "Uint8Array":
+      return decodeBase64Url(json.value);
+    case "bigint":
+      return BigInt(json.value);
+    case "boolean":
+    case "string":
+      return json.value;
+    case "number":
+      if (json.value === "Infinity") {
+        return Infinity;
+      }
+      if (json.value === "-Infinity") {
+        return -Infinity;
+      }
+      if (json.value === "NaN") {
+        return NaN;
+      }
+      return json.value;
+    default:
+      // deno-lint-ignore no-explicit-any
+      throw new TypeError(`Unexpected key part type: "${(json as any).type}".`);
+  }
+}
+
+/**
+ * Deserialize {@linkcode KvKeyJSON} to a {@linkcode Deno.KvKey}.
+ *
+ * @param json The JSON representation of the key.
+ * @returns The deserialized key.
+ * @example Deserialize a key from JSON
+ *
+ * ```ts
+ * import { toKey } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = [
+ *   { "type": "string", "value": "a" },
+ *   { "type": "bigint", "value": "100" }
+ * ] as const;
+ * const key = toKey(json);
+ * assertEquals(key, ["a", 100n]);
+ * ```
+ */
+export function toKey(json: KvKeyJSON): Deno.KvKey {
+  return json.map(toKeyPart);
+}
+
+/**
+ * Deserialize {@linkcode KvArrayBufferJSON} to an {@linkcode ArrayBuffer} which
+ * can be stored in a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "ArrayBuffer", value: "AQID" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new Uint8Array([1, 2, 3]).buffer);
+ * ```
+ */
+export function toValue(json: KvArrayBufferJSON): ArrayBuffer;
+/**
+ * Deserialize {@linkcode KvArrayJSON} to an array which can be stored in a Deno
+ * KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "Array", value: [ { type: "number", value: 1 } ] } as const;
+ * const value = toValue(json);
+ * assertEquals(value, [1]);
+ * ```
+ */
+export function toValue(json: KvArrayJSON): unknown[];
+/**
+ * Deserialize {@linkcode KvBigIntJSON} to a bigint which can be stored in a
+ * Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "bigint", value: "100" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, 100n);
+ * ```
+ */
+export function toValue(json: KvBigIntJSON): bigint;
+/**
+ * Deserialize {@linkcode KvBooleanJSON} to a boolean which can be stored in a
+ * Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "boolean", value: true } as const;
+ * const value = toValue(json);
+ * assertEquals(value, true);
+ * ```
+ */
+export function toValue(json: KvBooleanJSON): boolean;
+/**
+ * Deserialize {@linkcode KvDataViewJSON} to a {@linkcode DataView} which can
+ * be stored in a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "DataView", value: "AQID" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new DataView(new Uint8Array([1, 2, 3]).buffer));
+ * ```
+ */
+export function toValue(json: KvDataViewJSON): DataView;
+/**
+ * Deserialize {@linkcode KvDateJSON} to a {@linkcode Date} which can be stored
+ * in a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "Date", value: "2023-12-16T17:24:00.000Z" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new Date("2023-12-16T17:24:00.000Z"));
+ * ```
+ */
+export function toValue(json: KvDateJSON): Date;
+/**
+ * Deserialize {@linkcode KvErrorJSON} to an error value which can be stored in
+ * a Deno KV store.
+ *
+ * @typeParam ErrorType The type of error that can be deserialized
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assert } from "@std/assert";
+ *
+ * const json = {
+ *   type: "TypeError",
+ *   value: { message: "an error", stack: `Line\nLine` },
+ * } as const;
+ * const value = toValue(json);
+ * assert(value instanceof TypeError);
+ * ```
+ */
+export function toValue<ErrorType extends CloneableErrorTypes>(
+  json: KvErrorJSON<ErrorType>,
+): CloneableErrors[ErrorType];
+/**
+ * Deserialize {@linkcode KvKvU64JSON} to a {@linkcode Deno.KvU64} which can be
+ * stored in a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "KvU64", value: "100" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new Deno.KvU64(100n));
+ * ```
+ */
+export function toValue(json: KvKvU64JSON): Deno.KvU64;
+/**
+ * Deserialize {@linkcode KvMapJSON} to a {@linkcode Map} which can be stored in
+ * a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = toValue({ type: "Map", value: [
+ *   [{ type: "string", value: "a" }, { type: "string", value: "b" }]
+ * ] });
+ * assertEquals(value, new Map([["a", "b"]]));
+ * ```
+ */
+export function toValue(json: KvMapJSON): Map<unknown, unknown>;
+/**
+ * Deserialize {@linkcode KvNullJSON} to a `null` which can be stored in a Deno
+ * KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assert } from "@std/assert";
+ *
+ * const json = { type: "null", value: null } as const;
+ * const value = toValue(json);
+ * assert(value === null);
+ * ```
+ */
+export function toValue(json: KvNullJSON): null;
+/**
+ * Deserialize {@linkcode KvNumberJSON} to a number which can be stored in a
+ * Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "number", value: 100 } as const;
+ * const value = toValue(json);
+ * assertEquals(value, 100);
+ * ```
+ */
+export function toValue(json: KvNumberJSON): number;
+/**
+ * Deserialize {@linkcode KvObjectJSON} to a value which can be stored in a Deno
+ * KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = {
+ *   type: "object",
+ *   value: { a: { type: "string", value: "b" } }
+ * } as const;
+ * const value = toValue(json);
+ * assertEquals(value, { a: "b" });
+ * ```
+ */
+export function toValue(json: KvObjectJSON): Record<string, unknown>;
+/**
+ * Deserialize {@linkcode KvRegExpJSON} to a {@linkcode RegExp} which can be
+ * stored in a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assert } from "@std/assert";
+ *
+ * const json = { type: "RegExp", value: "/abc/i" } as const;
+ * const value = toValue(json);
+ * assert(value instanceof RegExp);
+ * ```
+ */
+export function toValue(json: KvRegExpJSON): RegExp;
+/**
+ * Deserialize {@linkcode KvSetJSON} to a {@linkcode Set} which can be stored in
+ * a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "Set", value: [{ type: "string", value: "a" }] } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new Set(["a"]));
+ * ```
+ */
+export function toValue(json: KvSetJSON): Set<unknown>;
+/**
+ * Deserialize {@linkcode KvStringJSON} to a string which can be stored in a
+ * Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "string", value: "value" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, "value");
+ * ```
+ */
+export function toValue(json: KvStringJSON): string;
+/**
+ * Deserialize {@linkcode KvTypedArrayJSON} to a typed array which can be stored
+ * in a Deno KV store.
+ *
+ * @typeParam ArrayType The type of the typed array, which is inferred from the
+ * value.
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "Uint8Array", value: "AQID" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, new Uint8Array([1, 2, 3]));
+ * ```
+ */
+export function toValue<ArrayType extends TypedArrayTypes>(
+  json: KvTypedArrayJSON<ArrayType>,
+): TypedArrayMap[ArrayType];
+/**
+ * Deserialize {@linkcode KvUndefinedJSON} to `undefined` which can be stored in
+ * a Deno KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assert } from "@std/assert";
+ *
+ * const json = { type: "undefined" } as const;
+ * const value = toValue(json);
+ * assert(value === undefined);
+ * ```
+ */
+export function toValue(json: KvUndefinedJSON): undefined;
+/**
+ * Deserialize {@linkcode KvValueJSON} to a value which can be stored in a Deno
+ * KV store.
+ *
+ * @param json The JSON representation of the value.
+ * @returns The deserialized value.
+ * @example Deserialize a value from JSON
+ *
+ * ```ts
+ * import { toValue } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = { type: "string", value: "value" } as const;
+ * const value = toValue(json);
+ * assertEquals(value, "value");
+ * ```
+ */
+export function toValue(json: KvValueJSON): unknown;
+export function toValue(json: KvValueJSON): unknown {
+  switch (json.type) {
+    case "Array":
+      return json.value.map(toValue);
+    case "Map":
+      return new Map(json.value.map((
+        [key, value]: [KvValueJSON, KvValueJSON],
+      ) => [toValue(key), toValue(value)]) as [unknown, unknown][]);
+    case "object":
+      return decodeObject(json.value);
+    case "Set":
+      return new Set(json.value.map(toValue));
+    case "null":
+      return json.value;
+    case "ArrayBuffer":
+      return decodeBase64Url(json.value).buffer;
+    case "BigInt64Array":
+    case "BigUint64Array":
+    case "Float32Array":
+    case "Float64Array":
+    case "Int16Array":
+    case "Int32Array":
+    case "Int8Array":
+    case "Uint16Array":
+    case "Uint32Array":
+    case "Uint8Array":
+    case "Uint8ClampedArray":
+      return toTypedArray(json);
+    case "DataView":
+      return new DataView(decodeBase64Url(json.value).buffer);
+    case "Date":
+      return new Date(json.value);
+    case "Error":
+    case "EvalError":
+    case "RangeError":
+    case "ReferenceError":
+    case "SyntaxError":
+    case "TypeError":
+    case "URIError":
+      return toError(json);
+    case "KvU64":
+      return new Deno.KvU64(BigInt(json.value));
+    case "RegExp": {
+      const parts = json.value.split("/");
+      const flags = parts.pop();
+      const [, ...pattern] = parts;
+      return new RegExp(pattern.join("/"), flags);
+    }
+    case "bigint":
+    case "boolean":
+    case "number":
+    case "string":
+      return toKeyPart(json);
+    case "undefined":
+      return undefined;
+    default:
+      // deno-lint-ignore no-explicit-any
+      throw new TypeError(`Unexpected value type: "${(json as any).type}"`);
+  }
+}
+
+/**
+ * Deserialize a {@linkcode KvEntryJSON} to a {@linkcode Deno.KvEntry}.
+ *
+ * @typeParam T The type of the value of the entry.
+ * @param entry The entry to deserialize.
+ * @returns The deserialized entry.
+ * @example Deserialize an entry from JSON
+ *
+ * ```ts
+ * import { toEntry } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = {
+ *   key: [ { type: "string", value: "a" } ],
+ *   value: { type: "string", value: "b" },
+ *   versionstamp: "00000123456789abcdef",
+ * } as const;
+ * const entry = toEntry(json);
+ * assertEquals(entry, {
+ *   key: ["a"],
+ *   value: "b",
+ *   versionstamp: "00000123456789abcdef",
+ * });
+ * ```
+ */
+export function toEntry<T>(entry: KvEntryJSON): Deno.KvEntry<T> {
+  const { key, value, versionstamp } = entry;
+  return {
+    key: key.map(toKeyPart),
+    value: toValue(value) as T,
+    versionstamp,
+  };
+}
+
+/**
+ * Deserialize a {@linkcode KvEntryMaybeJSON} to a
+ * {@linkcode Deno.KvEntryMaybe}.
+ *
+ * @typeParam T The type of the value of the entry.
+ * @param maybeEntry The entry to deserialize.
+ * @returns The deserialized entry.
+ * @example Deserialize an entry maybe from JSON
+ *
+ * ```ts
+ * import { toEntryMaybe } from "@deno/kv-utils/json";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const json = {
+ *   key: [ { type: "string", value: "a" } ],
+ *   value: null,
+ *   versionstamp: null,
+ * } as const;
+ * const maybeEntry = toEntryMaybe(json);
+ * assertEquals(maybeEntry, {
+ *   key: ["a"],
+ *   value: null,
+ *   versionstamp: null,
+ * });
+ * ```
+ */
+export function toEntryMaybe<T>(
+  maybeEntry: KvEntryMaybeJSON,
+): Deno.KvEntryMaybe<T> {
+  const { key, value, versionstamp } = maybeEntry;
+  return {
+    key: key.map(toKeyPart),
+    value: value === null ? null : toValue(value),
+    versionstamp,
+  } as Deno.KvEntryMaybe<T>;
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,95 @@
 // Copyright 2024 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Utilities for working with {@linkcode Deno.Kv}.
+ *
+ * ## Working with JSON
+ *
+ * {@linkcode Deno.Kv} stores are able to store values that are serializable
+ * using the structured clone algorithm. The challenge is that supports a lot
+ * of types that are not serializable using JSON. To work around this, you can
+ * use the the utilities to convert values which can be safely serialized to
+ * JSON as well as deserialize them back. This makes it possible to fully
+ * represent entries and values in a browser, or communicate them between Deno
+ * processes.
+ *
+ * The JSON utilities are:
+ *
+ * - {@linkcode entryMaybeToJSON} - Convert a {@linkcode Deno.KvEntryMaybe} to
+ *   JSON.
+ * - {@linkcode entryToJSON} - Convert a {@linkcode Deno.KvEntry} to JSON.
+ * - {@linkcode keyToJSON} - Convert a {@linkcode Deno.KvKey} to JSON.
+ * - {@linkcode keyPartToJSON} - Convert a {@linkcode Deno.KvKeyPart} to JSON.
+ * - {@linkcode valueToJSON} - Convert a value which can be stored in Deno KV to
+ *   JSON.
+ * - {@linkcode toEntry} - Convert a JSON object to a {@linkcode Deno.KvEntry}.
+ * - {@linkcode toEntryMaybe} - Convert a JSON object to a
+ *   {@linkcode Deno.KvEntryMaybe}.
+ * - {@linkcode toKey} - Convert a JSON object to a {@linkcode Deno.KvKey}.
+ * - {@linkcode toKeyPart} - Convert a JSON object to a
+ *   {@linkcode Deno.KvKeyPart}.
+ * - {@linkcode toValue} - Convert a JSON object to a value which can be stored
+ *   in Deno KV.
+ *
+ * ### Examples
+ *
+ * Taking a maybe entry from Deno.Kv and converting it to JSON and sending it
+ * as a response:
+ *
+ * ```ts ignore
+ * import { entryMaybeToJSON } from "@deno/kv-utils";
+ *
+ * const db = await Deno.openKv();
+ *
+ * Deno.serve(async (_req) => {
+ *   const maybeEntry = await db.get(["a"]);
+ *   const json = entryMaybeToJSON(maybeEntry);
+ *   return Response.json(json);
+ * });
+ * ```
+ *
+ * Taking a value that was serialized to JSON in a browser and storing it in
+ * Deno KV:
+ *
+ * ```ts ignore
+ * import { toValue } from "@deno/kv-utils";
+ *
+ * const db = await Deno.openKv();
+ *
+ * Deno.serve(async (req) => {
+ *   const json = await req.json();
+ *   const value = toValue(json);
+ *   await db.set(["a"], value);
+ *   return new Response(null, { status: 204 });
+ * });
+ * ```
+ *
+ * ## Estimating the size of a value
+ *
+ * When working with Deno KV and there is a need to have transactions be
+ * infallible, it is helpful to be able to estimate the size of a value before
+ * storing it. This is because there are limits on the size of values that can
+ * be stored in Deno KV, as well as the size of atomic operations.
+ *
+ * Deno KV stores values by using the V8 serialization format, which converts
+ * objects to a binary format and then that value is stored in the KV store.
+ *
+ * The {@linkcode estimateSize} function can be used to estimate the size of a
+ * value in bytes. While it is not 100% accurate, it is 10x faster than using
+ * the V8 serialize function, which is not available in some environments.
+ *
+ * ### Example
+ *
+ * ```ts
+ * import { estimateSize } from "@deno/kv-utils";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const value = { a: new Map([[{ a: 1 }, { b: /234/ }]]), b: false };
+ * assertEquals(estimateSize(value), 36);
+ * ```
+ *
+ * @module
+ */
+
+export * from "./json.ts";
+export * from "./estimate_size.ts";

--- a/test.ts
+++ b/test.ts
@@ -1,2 +1,0 @@
-// Copyright 2024 the Deno authors. All rights reserved. MIT license.
-Deno.test("test", () => {});


### PR DESCRIPTION
Provides two areas of capability adapted from `kv-toolbox`:

- [kv-toolbox/json](https://jsr.io/@kitsonk/kv-toolbox/doc/json) - a set of utilities and types that are able to serialize and deserialize all of the keys and values that are supported by Deno KV in JSON. This is very useful when having to represent Deno KV data in a browser or transmit Deno KV data "over the wire" while being able to accurately preserve the item.
- [kv-toolbox/size_of](https://jsr.io/@kitsonk/kv-toolbox/doc/size_of) - a function that estimates the byte size of a serialized value in Deno KV. Currently the [documentation](https://docs.deno.com/api/deno/~/Deno.Kv) suggests to use `JSON.stringify()` to estimate the size of values. The problem is that is totally ineffective at estimating complex objects which can be stored in Deno KV but do not serialize properly to JSON (e.g. typed arrays, RegExp, Set, Map, Error, Date, bigint, etc.). While taking the byte length of V8 serialize is more accurate it isn't available in Deploy and is 10x slower than `sizeOf()`.

Closes: https://github.com/denoland/std/issues/6123