### PR TITLE
chore: align types to current typescript

### DIFF
--- a/import_export.test.ts
+++ b/import_export.test.ts
@@ -16,7 +16,7 @@ Deno.test({
     const kv = await setup();
     await kv.set(["a"], 100n);
     await kv.set(["b"], new Uint8Array([1, 2, 3]));
-    let u8 = new Uint8Array();
+    let u8: Uint8Array<ArrayBufferLike> = new Uint8Array();
     for await (const chunk of exportEntries(kv, { prefix: [] })) {
       u8 = concat([u8, chunk]);
     }
@@ -63,7 +63,7 @@ Deno.test({
     const response = exportEntries(kv, { prefix: [] }, { type: "response" });
     assertEquals(response.headers.get("content-type"), "application/x-ndjson");
     assertEquals(response.headers.get("content-disposition"), null);
-    let u8 = new Uint8Array();
+    let u8 = new Uint8Array() as Uint8Array<ArrayBufferLike>;
     for await (const chunk of exportEntries(kv, { prefix: [] })) {
       u8 = concat([u8, chunk]);
     }
@@ -93,7 +93,7 @@ Deno.test({
       response.headers.get("content-disposition"),
       `attachment; filename="export.ndjson"`,
     );
-    let u8 = new Uint8Array();
+    let u8: Uint8Array<ArrayBufferLike> = new Uint8Array();
     for await (const chunk of exportEntries(kv, { prefix: [] })) {
       u8 = concat([u8, chunk]);
     }

--- a/import_export.ts
+++ b/import_export.ts
@@ -437,10 +437,10 @@ export class ImportError extends Error {
 export async function importEntries(
   db: Deno.Kv,
   data:
-    | ReadableStream<Uint8Array>
+    | ReadableStream<Uint8Array<ArrayBufferLike>>
     | Blob
     | ArrayBufferView
-    | ArrayBuffer
+    | ArrayBufferLike
     | string,
   options: ImportEntriesOptions = {},
 ): Promise<ImportEntriesResult> {
@@ -459,7 +459,7 @@ export async function importEntries(
   } else if (data instanceof Blob) {
     stream = data.stream().pipeThrough(transformer);
   } else {
-    stream = new Blob([data]).stream().pipeThrough(transformer);
+    stream = new Blob([data as ArrayBuffer]).stream().pipeThrough(transformer);
   }
   const reader = stream.getReader();
   let count = 0;

--- a/json.ts
+++ b/json.ts
@@ -588,7 +588,7 @@ function errorToJSON(error: Error): KvErrorJSON {
  * @private
  */
 function typedArrayToJSON(typedArray: ArrayBufferView): KvTypedArrayJSON {
-  const value = encodeBase64Url(typedArray.buffer);
+  const value = encodeBase64Url(typedArray.buffer as ArrayBuffer);
   const byteLength = typedArray.byteLength;
   if (typedArray instanceof Int8Array) {
     return { type: "Int8Array", value, byteLength };
@@ -1078,7 +1078,7 @@ export function valueToJSON(value: unknown): KvValueJSON {
       if (value instanceof DataView) {
         return {
           type: "DataView",
-          value: encodeBase64Url(value.buffer),
+          value: encodeBase64Url(value.buffer as ArrayBuffer),
           byteLength: value.byteLength,
         };
       }

--- a/line_transform_stream.ts
+++ b/line_transform_stream.ts
@@ -30,7 +30,7 @@ function stripEol(u8: Uint8Array): Uint8Array {
  * of string lines.
  */
 export class LinesTransformStream extends TransformStream<Uint8Array, string> {
-  #buffer = new Uint8Array(0);
+  #buffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
   #pos = 0;
 
   constructor() {


### PR DESCRIPTION
As TypeScript has evolved, there are now several situations where assignability of byte arrays and array buffers were incompatible. This PR cleans that up so that type checking passes.